### PR TITLE
LOCI-477 GCP: The provider hashicorp/google does not support resource type "google_runtimeconfig_config"

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -51,14 +51,14 @@ For a list of services available, visit the [API library page](https://console.c
 
 ## Configure Terraform
 
-Download Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.0.4.zip) and extract tarball:
+Download Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.0.5.zip) and extract tarball:
 ```shell
-curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.0.4.tar.gz | tar xz
+curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.0.5.tar.gz | tar xz
 ```
 
 Change Terraform variables according you requirements:
 ```shell
-cd exascaler-cloud-terraform-scripts-2.0.4/gcp
+cd exascaler-cloud-terraform-scripts-2.0.5/gcp
 vi terraform.tfvars
 ```
 

--- a/gcp/cls.tf
+++ b/gcp/cls.tf
@@ -1,4 +1,5 @@
 resource "google_compute_disk" "clt" {
+  provider = google-beta
   for_each = local.compute_disk.clt
   type     = each.value.type
   size     = each.value.size
@@ -7,6 +8,7 @@ resource "google_compute_disk" "clt" {
 }
 
 resource "google_compute_instance" "cls" {
+  provider         = google-beta
   count            = var.cls.node_count
   name             = format("%s-%s%d", local.prefix, "cls", count.index)
   zone             = var.zone

--- a/gcp/mds.tf
+++ b/gcp/mds.tf
@@ -1,4 +1,5 @@
 resource "google_compute_disk" "mdt" {
+  provider = google-beta
   for_each = local.compute_disk.mdt
   type     = each.value.type
   size     = each.value.size
@@ -16,6 +17,7 @@ resource "google_compute_disk" "mdt" {
 }
 
 resource "google_compute_instance" "mds" {
+  provider         = google-beta
   count            = var.mds.node_count
   name             = format("%s-%s%d", local.prefix, "mds", count.index)
   zone             = var.zone

--- a/gcp/mgs.tf
+++ b/gcp/mgs.tf
@@ -1,4 +1,5 @@
 resource "google_compute_disk" "mgt" {
+  provider = google-beta
   for_each = local.compute_disk.mgt
   type     = each.value.type
   size     = each.value.size
@@ -16,6 +17,7 @@ resource "google_compute_disk" "mgt" {
 }
 
 resource "google_compute_disk" "mnt" {
+  provider = google-beta
   for_each = local.compute_disk.mnt
   type     = each.value.type
   size     = each.value.size
@@ -33,6 +35,7 @@ resource "google_compute_disk" "mnt" {
 }
 
 resource "google_compute_instance" "mgs" {
+  provider         = google-beta
   count            = var.mgs.node_count
   name             = format("%s-%s%d", local.prefix, "mgs", count.index)
   zone             = var.zone

--- a/gcp/network.tf
+++ b/gcp/network.tf
@@ -1,4 +1,5 @@
 resource "google_compute_network" "exa" {
+  provider                = google-beta
   count                   = var.network.new ? 1 : 0
   name                    = format("%s-%s", local.prefix, "network")
   mtu                     = var.network.mtu
@@ -7,6 +8,7 @@ resource "google_compute_network" "exa" {
 }
 
 resource "google_compute_subnetwork" "exa" {
+  provider                 = google-beta
   count                    = var.subnetwork.new ? 1 : 0
   name                     = format("%s-%s", local.prefix, "subnetwork")
   network                  = local.network.name
@@ -16,12 +18,14 @@ resource "google_compute_subnetwork" "exa" {
 }
 
 data "google_compute_subnetwork" "exa" {
-  count  = var.subnetwork.new ? 0 : 1
-  name   = var.subnetwork.name
-  region = local.region
+  provider = google-beta
+  count    = var.subnetwork.new ? 0 : 1
+  name     = var.subnetwork.name
+  region   = local.region
 }
 
 resource "google_compute_firewall" "local" {
+  provider  = google-beta
   count     = var.security.enable_local ? 1 : 0
   name      = format("%s-%s", local.prefix, "allow-local")
   network   = local.network.name
@@ -38,6 +42,7 @@ resource "google_compute_firewall" "local" {
 }
 
 resource "google_compute_firewall" "lnet" {
+  provider  = google-beta
   count     = var.security.enable_local ? 1 : 0
   name      = format("%s-%s", local.prefix, "allow-lnet")
   network   = local.network.name
@@ -57,6 +62,7 @@ resource "google_compute_firewall" "lnet" {
 }
 
 resource "google_compute_firewall" "repo" {
+  provider  = google-beta
   count     = var.security.enable_local ? 1 : 0
   name      = format("%s-%s", local.prefix, "allow-repo")
   network   = local.network.name
@@ -76,6 +82,7 @@ resource "google_compute_firewall" "repo" {
 }
 
 resource "google_compute_firewall" "ssh" {
+  provider  = google-beta
   count     = var.security.enable_ssh ? 1 : 0
   name      = format("%s-%s", local.prefix, "allow-ssh")
   network   = local.network.name
@@ -95,6 +102,7 @@ resource "google_compute_firewall" "ssh" {
 }
 
 resource "google_compute_firewall" "http" {
+  provider  = google-beta
   count     = var.security.enable_http ? 1 : 0
   name      = format("%s-%s", local.prefix, "allow-http")
   network   = local.network.name
@@ -114,13 +122,15 @@ resource "google_compute_firewall" "http" {
 }
 
 resource "google_compute_router" "exa" {
-  count   = var.network.nat ? 1 : 0
-  name    = format("%s-%s", local.prefix, "router")
-  region  = local.region
-  network = local.network.name
+  provider = google-beta
+  count    = var.network.nat ? 1 : 0
+  name     = format("%s-%s", local.prefix, "router")
+  region   = local.region
+  network  = local.network.name
 }
 
 resource "google_compute_router_nat" "exa" {
+  provider                           = google-beta
   count                              = var.network.nat ? 1 : 0
   name                               = format("%s-%s", local.prefix, "nat")
   router                             = google_compute_router.exa.0.name

--- a/gcp/oss.tf
+++ b/gcp/oss.tf
@@ -1,4 +1,5 @@
 resource "google_compute_disk" "ost" {
+  provider = google-beta
   for_each = local.compute_disk.ost
   type     = each.value.type
   size     = each.value.size
@@ -16,6 +17,7 @@ resource "google_compute_disk" "ost" {
 }
 
 resource "google_compute_instance" "oss" {
+  provider         = google-beta
   count            = var.oss.node_count
   name             = format("%s-%s%d", local.prefix, "oss", count.index)
   zone             = var.zone


### PR DESCRIPTION
**LOCI-477 GCP: The provider hashicorp/google does not support resource type "google_runtimeconfig_config"**

Changed provider to google-beta due to the upstream changes:

https://github.com/hashicorp/terraform-provider-google/releases

v4.0.0

BREAKING CHANGES:

runtimeconfig: removed the Runtime Configurator service from the google (GA) provider including google_runtimeconfig_config, google_runtimeconfig_variable, google_runtimeconfig_config_iam_policy, google_runtimeconfig_config_iam_binding, google_runtimeconfig_config_iam_member, data.google_runtimeconfig_config. They are only available in the google-beta provider, as the underlying service is in beta. (#10410)
