### PR TITLE
New configuration options

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -52,14 +52,14 @@ For a list of services available, visit the [API library page](https://console.c
 
 ## Configure Terraform
 
-Download Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.1.1.zip) and extract tarball:
+Download Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.1.2.zip) and extract tarball:
 ```shell
-curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.1.1.tar.gz | tar xz
+curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.1.2.tar.gz | tar xz
 ```
 
 Change Terraform variables according you requirements:
 ```shell
-cd exascaler-cloud-terraform-scripts-2.1.1/gcp
+cd exascaler-cloud-terraform-scripts-2.1.2/gcp
 vi terraform.tfvars
 ```
 
@@ -68,6 +68,8 @@ vi terraform.tfvars
 #### Common options
 | Variable  | Type     | Default         | Description |
 | --------: | -------: | --------------: | ----------- |
+| `prefix`  | `string` | `null`          | EXAScaler Cloud custom deployment prefix. Set this option to add a custom prefix to all created objects. |
+| `labels`  | `map`    | `{}`            | EXAScaler Cloud custom deployment labels. Set this option to add a custom labels to all created objects. |
 | `fsname`  | `string` | `exacloud`      | EXAScaler Cloud filesystem name. |
 | `project` | `string` | `project-id`    | Project ID to manage resources. [Learn more](https://cloud.google.com/resource-manager/docs/creating-managing-projects). |
 | `zone`    | `string` | `us-central1-f` | Zone name to manage resources. [Learn more](https://cloud.google.com/compute/docs/regions-zones). |
@@ -445,8 +447,8 @@ tar pcfz backup.tgz *.tf terraform.tfvars terraform.tfstate
 Update Terraform scripts using the latest available EXAScaler Cloud Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform):
 ```shell
 cd /path/to
-curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.1.1.tar.gz | tar xz
-cd exascaler-cloud-terraform-scripts-2.1.1/gcp
+curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.1.2.tar.gz | tar xz
+cd exascaler-cloud-terraform-scripts-2.1.2/gcp
 ```
 
 Copy the `terraform.tfstate` file from the existing Terraform directory:

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -162,7 +162,7 @@ locals {
   timeout    = 300
   label      = lower(replace(local.product, " ", "-"))
   region     = join("-", slice(split("-", var.zone), 0, 2))
-  prefix     = format("%s-%s", local.label, random_id.exa.hex)
+  prefix     = coalesce(var.prefix, format("%s-%s", local.label, random_id.exa.hex))
   ssh_key    = var.security.admin != null && var.security.public_key != null ? format("%s:%s", var.security.admin, file(var.security.public_key)) : null
   http_tag   = format("%s-%s", local.prefix, "http-server")
   node_count = var.mgs.node_count + var.mds.node_count + var.oss.node_count + var.cls.node_count
@@ -186,6 +186,7 @@ locals {
   }
 
   labels = merge(
+    var.labels,
     data.google_compute_image.exa.labels,
     {
       deployment = local.prefix

--- a/gcp/terraform.tfvars
+++ b/gcp/terraform.tfvars
@@ -1,3 +1,16 @@
+# EXAScaler Cloud custom deployment prefix
+# set this option to add a custom prefix to all created objects
+# only lowercase alphanumeric characters are allowed,
+# and the value must be 1-32 characters long
+# keep this value blank to use the default setting
+# set prefix = null to use the default value (exascaler-cloud-XXXX)
+prefix = null
+
+# EXAScaler Cloud custom deployment labels
+# set this option to add a custom labels to all created objects
+# https://cloud.google.com/resource-manager/docs/creating-managing-labels
+labels = {}
+
 # EXAScaler Cloud filesystem name
 # only alphanumeric characters are allowed,
 # and the value must be 1-8 characters long

--- a/gcp/variable.tf
+++ b/gcp/variable.tf
@@ -1,3 +1,41 @@
+variable "prefix" {
+  type        = string
+  default     = ""
+  description = "EXAScaler Cloud deployment prefix"
+
+  validation {
+    condition     = var.prefix == null ? true : can(regex("^[a-z][0-9a-z_-]{0,31}$", var.prefix))
+    error_message = "The prefix value can contain only lowercase letters, numeric characters, underscores, dashes, must start with a lowercase letter and have a length of 1-32 characters."
+  }
+}
+
+variable "labels" {
+  type        = map(any)
+  default     = {}
+  description = "EXAScaler Cloud deployment labels"
+
+  validation {
+    condition     = length(var.labels) <= 64
+    error_message = "The number of labels must be less than or equal to 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for name, value in var.labels :
+      can(regex("^\\p{Ll}[\\p{Ll}\\p{Nd}_-]{0,62}$", name))
+    ])
+    error_message = "The labels keys can contain only lowercase letters, numeric characters, underscores, dashes, must start with a lowercase letter and have a length of 1-63 characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for name, value in var.labels :
+      can(regex("^[\\p{Ll}\\p{Nd}_-]{0,63}$", value))
+    ])
+    error_message = "The labels values can contain only lowercase letters, numeric characters, underscores, dashes and have a length of 0-63 characters."
+  }
+}
+
 variable "fsname" {
   type        = string
   default     = "exacloud"
@@ -174,7 +212,7 @@ variable "image" {
 
   default = {
     project = "ddn-public"
-    name    = "exascaler-cloud-v522-centos7"
+    name    = "exascaler-cloud-v523-centos7"
   }
 
   description = "Source image options"


### PR DESCRIPTION
GWC-5 terraform module should receive "labels" input that is applied to all resources created on GCP
GWC-6 Image default value should be updated to "exascaler-cloud-v523-centos7"
GWC-7 Provide the user with a way of defining instance names (or a prefix)
