### PR TITLE
LOCI-652: EXAScaler Cloud 6.3.2 for Azure and GCP

### DIFF
--- a/az/README.md
+++ b/az/README.md
@@ -40,16 +40,16 @@ The steps below will show how to create a EXAScaler Cloud environment on Microso
 
 ## Supported products
 
-| Product         | Version | Base OS Vendor and Version   | Stock Keeping Unit (`SKU`)   |
-| --------------- | ------- | ---------------------------- | ---------------------------- |
-| EXAScaler Cloud | 5.2.6   | Red Hat Enterprise Linux 7.9 | `exascaler_cloud_5_2_redhat` |
-| EXAScaler Cloud | 5.2.6   | CentOS Linux 7.9             | `exascaler_cloud_5_2_centos` |
-| EXAScaler Cloud | 6.1.0   | Red Hat Enterprise Linux 7.9 | `exascaler_cloud_6_1_redhat` |
-| EXAScaler Cloud | 6.1.0   | CentOS Linux 7.9             | `exascaler_cloud_6_1_centos` |
-| EXAScaler Cloud | 6.2.0   | Red Hat Enterprise Linux 8.7 | `exascaler_cloud_6_2_redhat` |
-| EXAScaler Cloud | 6.2.0   | Rocky Linux 8.7              | `exascaler_cloud_6_2_rocky`  |
-| EXAScaler Cloud | 6.3.0   | Red Hat Enterprise Linux 8.8 | `exascaler_cloud_6_3_redhat` |
-| EXAScaler Cloud | 6.3.0   | Rocky Linux 8.8              | `exascaler_cloud_6_3_rocky`  |
+| Product         | Version | Base OS Vendor and Version    | Stock Keeping Unit (`SKU`)   |
+| --------------- | ------- | ----------------------------- | ---------------------------- |
+| EXAScaler Cloud | 5.2.6   | Red Hat Enterprise Linux 7.9  | `exascaler_cloud_5_2_redhat` |
+| EXAScaler Cloud | 5.2.6   | CentOS Linux 7.9              | `exascaler_cloud_5_2_centos` |
+| EXAScaler Cloud | 6.1.0   | Red Hat Enterprise Linux 7.9  | `exascaler_cloud_6_1_redhat` |
+| EXAScaler Cloud | 6.1.0   | CentOS Linux 7.9              | `exascaler_cloud_6_1_centos` |
+| EXAScaler Cloud | 6.2.0   | Red Hat Enterprise Linux 8.7  | `exascaler_cloud_6_2_redhat` |
+| EXAScaler Cloud | 6.2.0   | Rocky Linux 8.7               | `exascaler_cloud_6_2_rocky`  |
+| EXAScaler Cloud | 6.3.2   | Red Hat Enterprise Linux 8.10 | `exascaler_cloud_6_3_redhat` |
+| EXAScaler Cloud | 6.3.2   | Rocky Linux 8.10              | `exascaler_cloud_6_3_rocky`  |
 
 ## Client packages
 
@@ -61,34 +61,43 @@ EXAScaler Cloud client software comprises a set of kernel modules which must be 
 | Red Hat   | RHEL    | `7.6`       | `x86_64`  | `3.10.0-957.99.1.el7.x86_64`      | `3.10.0`                        |
 | Red Hat   | RHEL    | `7.7`       | `x86_64`  | `3.10.0-1062.77.1.el7.x86_64`     | `3.10.0`                        |
 | Red Hat   | RHEL    | `7.8`       | `x86_64`  | `3.10.0-1127.19.1.el7.x86_64`     | `3.10.0`                        |
-| Red Hat   | RHEL    | `7.9`       | `x86_64`  | `3.10.0-1160.108.1.el7.x86_64`    | `3.10.0`                        |
+| Red Hat   | RHEL    | `7.9`       | `x86_64`  | `3.10.0-1160.119.1.el7.x86_64`    | `3.10.0`                        |
 | Red Hat   | RHEL    | `8.0`       | `x86_64`  | `4.18.0-80.31.1.el8_0.x86_64`     | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.1`       | `x86_64`  | `4.18.0-147.94.1.el8_1.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.2`       | `x86_64`  | `4.18.0-193.120.1.el8_2.x86_64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.2`       | `x86_64`  | `4.18.0-193.141.1.el8_2.x86_64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.3`       | `x86_64`  | `4.18.0-240.22.1.el8_3.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.4`       | `x86_64`  | `4.18.0-305.120.1.el8_4.x86_64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.4`       | `x86_64`  | `4.18.0-305.148.1.el8_4.x86_64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.5`       | `x86_64`  | `4.18.0-348.23.1.el8_5.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.6`       | `x86_64`  | `4.18.0-372.87.1.el8_6.x86_64`    | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.6`       | `aarch64` | `4.18.0-372.105.1.el8_6.aarch64`  | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.6`       | `x86_64`  | `4.18.0-372.134.1.el8_6.x86_64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.7`       | `aarch64` | `4.18.0-425.19.2.el8_7.aarch64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.7`       | `x86_64`  | `4.18.0-425.19.2.el8_7.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.8`       | `aarch64` | `4.18.0-477.43.1.el8_8.aarch64`   | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.8`       | `x86_64`  | `4.18.0-477.43.1.el8_8.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.9`       | `aarch64` | `4.18.0-513.11.1.el8_9.aarch64`   | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.9`       | `x86_64`  | `4.18.0-513.11.1.el8_9.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `9.0`       | `aarch64` | `5.14.0-70.85.1.el9_0.aarch64`    | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.0`       | `x86_64`  | `5.14.0-70.85.1.el9_0.x86_64`     | `5.14.0`                        |
+| Red Hat   | RHEL    | `8.8`       | `aarch64` | `4.18.0-477.86.1.el8_8.aarch64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.8`       | `x86_64`  | `4.18.0-477.86.1.el8_8.x86_64`    | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.9`       | `aarch64` | `4.18.0-513.24.1.el8_9.aarch64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.9`       | `x86_64`  | `4.18.0-513.24.1.el8_9.x86_64`    | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.10`      | `aarch64` | `4.18.0-553.40.1.el8_10.aarch64`  | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.10`      | `x86_64`  | `4.18.0-553.40.1.el8_10.x86_64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `9.0`       | `aarch64` | `5.14.0-70.101.1.el9_0.aarch64`   | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.0`       | `x86_64`  | `5.14.0-70.122.1.el9_0.x86_64`    | `5.14.0`                        |
 | Red Hat   | RHEL    | `9.1`       | `aarch64` | `5.14.0-162.23.1.el9_1.aarch64`   | `5.14.0`                        |
 | Red Hat   | RHEL    | `9.1`       | `x86_64`  | `5.14.0-162.23.1.el9_1.x86_64`    | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.2`       | `aarch64` | `5.14.0-284.48.1.el9_2.aarch64`   | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.2`       | `x86_64`  | `5.14.0-284.48.1.el9_2.x86_64`    | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.3`       | `aarch64` | `5.14.0-362.18.1.el9_3.aarch64`   | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.3`       | `x86_64`  | `5.14.0-362.18.1.el9_3.x86_64`    | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.2`       | `aarch64` | `5.14.0-284.99.1.el9_2.aarch64`   | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.2`       | `x86_64`  | `5.14.0-284.99.1.el9_2.x86_64`    | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.3`       | `aarch64` | `5.14.0-362.24.1.el9_3.aarch64`   | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.3`       | `x86_64`  | `5.14.0-362.24.1.el9_3.x86_64`    | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.4`       | `aarch64` | `5.14.0-427.50.1.el9_4.aarch64`   | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.4`       | `x86_64`  | `5.14.0-427.50.1.el9_4.x86_64`    | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.5`       | `aarch64` | `5.14.0-503.26.1.el9_5.aarch64`   | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.5`       | `x86_64`  | `5.14.0-503.26.1.el9_5.x86_64`    | `5.14.0`                        |
 | Canonical | Ubuntu  | `16.04 LTS` | `amd64`   | —                                 | `4.4 - 4.15`                    |
 | Canonical | Ubuntu  | `18.04 LTS` | `amd64`   | —                                 | `4.15 - 5.4`                    |
 | Canonical | Ubuntu  | `20.04 LTS` | `amd64`   | —                                 | `5.4 - 5.15`                    |
 | Canonical | Ubuntu  | `20.04 LTS` | `arm64`   | —                                 | `5.4 - 5.15`                    |
 | Canonical | Ubuntu  | `22.04 LTS` | `amd64`   | —                                 | `5.15 - 6.2`                    |
 | Canonical | Ubuntu  | `22.04 LTS` | `arm64`   | —                                 | `5.15 - 6.2`                    |
+| Canonical | Ubuntu  | `24.04 LTS` | `amd64`   | —                                 | `6.8 - TBD`                     |
+| Canonical | Ubuntu  | `24.04 LTS` | `arm64`   | —                                 | `6.8 - TBD`                     |
 
 Notes:
 * Client packages for `aarch64` and `arm64` architectures are available only for EXAScaler Cloud 6.3
@@ -204,14 +213,14 @@ az vm image terms accept --urn ddn-whamcloud-5345716:exascaler_cloud:exascaler_c
 
 ## Steps to configure Terraform
 
-Download Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.0.tar.gz) and extract the [tarball](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.0.tar.gz):
+Download Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.2.tar.gz) and extract the [tarball](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.2.tar.gz):
 ```shell
-curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.0.tar.gz | tar xz
+curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.2.tar.gz | tar xz
 ```
 
 Change Terraform variables according you requirements:
 ```shell
-cd exascaler-cloud-terraform-scripts-2.2.0/az
+cd exascaler-cloud-terraform-scripts-2.2.2/az
 vi terraform.tfvars
 ```
 
@@ -619,8 +628,8 @@ tar pcfz backup.tgz *.tf terraform.tfvars terraform.tfstate
 Update Terraform scripts using the latest available EXAScaler Cloud Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform):
 ```shell
 cd /path/to
-curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.0.tar.gz | tar xz
-cd exascaler-cloud-terraform-scripts-2.2.0/az
+curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.2.tar.gz | tar xz
+cd exascaler-cloud-terraform-scripts-2.2.2/az
 ```
 
 Copy the terraform.tfstate file from the existing Terraform directory:

--- a/az/cls.tf
+++ b/az/cls.tf
@@ -20,11 +20,11 @@ resource "azurerm_public_ip" "cls" {
 }
 
 resource "azurerm_network_interface" "cls" {
-  count                         = var.cls.node_count
-  name                          = format("%s-%s%d-%s", local.prefix, "cls", count.index, "network-interface")
-  location                      = local.resource_group.location
-  resource_group_name           = local.resource_group.name
-  enable_accelerated_networking = var.cls.accelerated_network
+  count                          = var.cls.node_count
+  name                           = format("%s-%s%d-%s", local.prefix, "cls", count.index, "network-interface")
+  location                       = local.resource_group.location
+  resource_group_name            = local.resource_group.name
+  accelerated_networking_enabled = var.cls.accelerated_network
   ip_configuration {
     name                          = format("%s-%s%d-%s", local.prefix, "cls", count.index, "private-ip")
     subnet_id                     = local.subnet.id

--- a/az/main.tf
+++ b/az/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.10.0"
+      version = ">= 4.0.0"
     }
   }
 }
@@ -137,7 +137,7 @@ resource "azurerm_portal_dashboard" "exa" {
 }
 
 locals {
-  loci      = "2.2.0"
+  loci      = "2.2.2"
   product   = "EXAScaler Cloud"
   profile   = "custom"
   templates = "templates"

--- a/az/mds.tf
+++ b/az/mds.tf
@@ -20,11 +20,11 @@ resource "azurerm_public_ip" "mds" {
 }
 
 resource "azurerm_network_interface" "mds" {
-  count                         = var.mds.node_count
-  name                          = format("%s-%s%d-%s", local.prefix, "mds", count.index, "network-interface")
-  location                      = local.resource_group.location
-  resource_group_name           = local.resource_group.name
-  enable_accelerated_networking = var.mds.accelerated_network
+  count                          = var.mds.node_count
+  name                           = format("%s-%s%d-%s", local.prefix, "mds", count.index, "network-interface")
+  location                       = local.resource_group.location
+  resource_group_name            = local.resource_group.name
+  accelerated_networking_enabled = var.mds.accelerated_network
   ip_configuration {
     name                          = format("%s-%s%d-%s", local.prefix, "mds", count.index, "private-ip")
     subnet_id                     = local.subnet.id

--- a/az/mgs.tf
+++ b/az/mgs.tf
@@ -20,11 +20,11 @@ resource "azurerm_public_ip" "mgs" {
 }
 
 resource "azurerm_network_interface" "mgs" {
-  count                         = var.mgs.node_count
-  name                          = format("%s-%s%d-%s", local.prefix, "mgs", count.index, "network-interface")
-  location                      = local.resource_group.location
-  resource_group_name           = local.resource_group.name
-  enable_accelerated_networking = var.mgs.accelerated_network
+  count                          = var.mgs.node_count
+  name                           = format("%s-%s%d-%s", local.prefix, "mgs", count.index, "network-interface")
+  location                       = local.resource_group.location
+  resource_group_name            = local.resource_group.name
+  accelerated_networking_enabled = var.mgs.accelerated_network
   ip_configuration {
     name                          = format("%s-%s%d-%s", local.prefix, "mgs", count.index, "private-ip")
     subnet_id                     = local.subnet.id

--- a/az/oss.tf
+++ b/az/oss.tf
@@ -20,11 +20,11 @@ resource "azurerm_public_ip" "oss" {
 }
 
 resource "azurerm_network_interface" "oss" {
-  count                         = var.oss.node_count
-  name                          = format("%s-%s%d-%s", local.prefix, "oss", count.index, "network-interface")
-  location                      = local.resource_group.location
-  resource_group_name           = local.resource_group.name
-  enable_accelerated_networking = var.oss.accelerated_network
+  count                          = var.oss.node_count
+  name                           = format("%s-%s%d-%s", local.prefix, "oss", count.index, "network-interface")
+  location                       = local.resource_group.location
+  resource_group_name            = local.resource_group.name
+  accelerated_networking_enabled = var.oss.accelerated_network
   ip_configuration {
     name                          = format("%s-%s%d-%s", local.prefix, "oss", count.index, "private-ip")
     subnet_id                     = local.subnet.id

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -53,13 +53,13 @@ The steps below will show how to create a EXAScaler Cloud environment on [Google
 | EXAScaler Cloud | 6.2.0   | Rocky Linux 8.7                                            | `exascaler-cloud-6-2-rocky-linux-8`               |
 | EXAScaler Cloud | 6.2.0   | Rocky Linux 8.7 optimized for GCP                          | `exascaler-cloud-6-2-rocky-linux-8-optimized-gcp` |
 | EXAScaler Cloud | 6.2.0   | CIS Rocky Linux 8.7 Benchmark v1.0.0 Level 1               | `exascaler-cloud-6-2-cis-rocky8-l1`               |
-| EXAScaler Cloud | 6.3.1   | Red Hat Enterprise Linux 8.10                              | `exascaler-cloud-6-3-rhel-8`                      |
-| EXAScaler Cloud | 6.3.1   | CIS Red Hat Enterprise Linux 8.10 Benchmark v2.0.0 Level 1 | `exascaler-cloud-6-3-cis-rhel8-l1`                |
-| EXAScaler Cloud | 6.3.1   | CIS Red Hat Enterprise Linux 8.10 Benchmark v2.0.0 Level 2 | `exascaler-cloud-6-3-cis-rhel8-l2`                |
-| EXAScaler Cloud | 6.3.1   | CIS Red Hat Enterprise Linux 8.10 STIG Benchmark v1.0.0    | `exascaler-cloud-6-3-cis-rhel8-stig`              |
-| EXAScaler Cloud | 6.3.1   | Rocky Linux 8.10                                           | `exascaler-cloud-6-3-rocky-linux-8`               |
-| EXAScaler Cloud | 6.3.1   | Rocky Linux 8.10 optimized for GCP                         | `exascaler-cloud-6-3-rocky-linux-8-optimized-gcp` |
-| EXAScaler Cloud | 6.3.1   | CIS Rocky Linux 8.10 Benchmark v1.0.0 Level 1              | `exascaler-cloud-6-3-cis-rocky8-l1`               |
+| EXAScaler Cloud | 6.3.2   | Red Hat Enterprise Linux 8.10                              | `exascaler-cloud-6-3-rhel-8`                      |
+| EXAScaler Cloud | 6.3.2   | CIS Red Hat Enterprise Linux 8.10 Benchmark v2.0.0 Level 1 | `exascaler-cloud-6-3-cis-rhel8-l1`                |
+| EXAScaler Cloud | 6.3.2   | CIS Red Hat Enterprise Linux 8.10 Benchmark v2.0.0 Level 2 | `exascaler-cloud-6-3-cis-rhel8-l2`                |
+| EXAScaler Cloud | 6.3.2   | CIS Red Hat Enterprise Linux 8.10 STIG Benchmark v1.0.0    | `exascaler-cloud-6-3-cis-rhel8-stig`              |
+| EXAScaler Cloud | 6.3.2   | Rocky Linux 8.10                                           | `exascaler-cloud-6-3-rocky-linux-8`               |
+| EXAScaler Cloud | 6.3.2   | Rocky Linux 8.10 optimized for GCP                         | `exascaler-cloud-6-3-rocky-linux-8-optimized-gcp` |
+| EXAScaler Cloud | 6.3.2   | CIS Rocky Linux 8.10 Benchmark v1.0.0 Level 1              | `exascaler-cloud-6-3-cis-rocky8-l1`               |
 
 ## Client packages
 
@@ -76,28 +76,30 @@ EXAScaler Cloud client software comprises a set of kernel modules which must be 
 | Red Hat   | RHEL    | `8.1`       | `x86_64`  | `4.18.0-147.94.1.el8_1.x86_64`    | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.2`       | `x86_64`  | `4.18.0-193.138.1.el8_2.x86_64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.3`       | `x86_64`  | `4.18.0-240.22.1.el8_3.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.4`       | `x86_64`  | `4.18.0-305.139.1.el8_4.x86_64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.4`       | `x86_64`  | `4.18.0-305.148.1.el8_4.x86_64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.5`       | `x86_64`  | `4.18.0-348.23.1.el8_5.x86_64`    | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.6`       | `aarch64` | `4.18.0-372.105.1.el8_6.aarch64`  | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.6`       | `x86_64`  | `4.18.0-372.121.1.el8_6.x86_64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.6`       | `x86_64`  | `4.18.0-372.134.1.el8_6.x86_64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.7`       | `aarch64` | `4.18.0-425.19.2.el8_7.aarch64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.7`       | `x86_64`  | `4.18.0-425.19.2.el8_7.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.8`       | `aarch64` | `4.18.0-477.70.1.el8_8.aarch64`   | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.8`       | `x86_64`  | `4.18.0-477.70.1.el8_8.x86_64`    | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.8`       | `aarch64` | `4.18.0-477.86.1.el8_8.aarch64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.8`       | `x86_64`  | `4.18.0-477.86.1.el8_8.x86_64`    | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.9`       | `aarch64` | `4.18.0-513.24.1.el8_9.aarch64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `8.9`       | `x86_64`  | `4.18.0-513.24.1.el8_9.x86_64`    | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.10`      | `aarch64` | `4.18.0-553.16.1.el8_10.aarch64`  | `4.18.0`                        |
-| Red Hat   | RHEL    | `8.10`      | `x86_64`  | `4.18.0-553.16.1.el8_10.x86_64`   | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.10`      | `aarch64` | `4.18.0-553.40.1.el8_10.aarch64`  | `4.18.0`                        |
+| Red Hat   | RHEL    | `8.10`      | `x86_64`  | `4.18.0-553.40.1.el8_10.x86_64`   | `4.18.0`                        |
 | Red Hat   | RHEL    | `9.0`       | `aarch64` | `5.14.0-70.101.1.el9_0.aarch64`   | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.0`       | `x86_64`  | `5.14.0-70.112.1.el9_0.x86_64`    | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.0`       | `x86_64`  | `5.14.0-70.122.1.el9_0.x86_64`    | `5.14.0`                        |
 | Red Hat   | RHEL    | `9.1`       | `aarch64` | `5.14.0-162.23.1.el9_1.aarch64`   | `5.14.0`                        |
 | Red Hat   | RHEL    | `9.1`       | `x86_64`  | `5.14.0-162.23.1.el9_1.x86_64`    | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.2`       | `aarch64` | `5.14.0-284.82.1.el9_2.aarch64`   | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.2`       | `x86_64`  | `5.14.0-284.84.1.el9_2.x86_64`    | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.2`       | `aarch64` | `5.14.0-284.99.1.el9_2.aarch64`   | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.2`       | `x86_64`  | `5.14.0-284.99.1.el9_2.x86_64`    | `5.14.0`                        |
 | Red Hat   | RHEL    | `9.3`       | `aarch64` | `5.14.0-362.24.1.el9_3.aarch64`   | `5.14.0`                        |
 | Red Hat   | RHEL    | `9.3`       | `x86_64`  | `5.14.0-362.24.1.el9_3.x86_64`    | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.4`       | `aarch64` | `5.14.0-427.35.1.el9_4.aarch64`   | `5.14.0`                        |
-| Red Hat   | RHEL    | `9.4`       | `x86_64`  | `5.14.0-427.35.1.el9_4.x86_64`    | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.4`       | `aarch64` | `5.14.0-427.50.1.el9_4.aarch64`   | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.4`       | `x86_64`  | `5.14.0-427.50.1.el9_4.x86_64`    | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.5`       | `aarch64` | `5.14.0-503.26.1.el9_5.aarch64`   | `5.14.0`                        |
+| Red Hat   | RHEL    | `9.5`       | `x86_64`  | `5.14.0-503.26.1.el9_5.x86_64`    | `5.14.0`                        |
 | Canonical | Ubuntu  | `16.04 LTS` | `amd64`   | —                                 | `4.4 - 4.15`                    |
 | Canonical | Ubuntu  | `18.04 LTS` | `amd64`   | —                                 | `4.15 - 5.4`                    |
 | Canonical | Ubuntu  | `20.04 LTS` | `amd64`   | —                                 | `5.4 - 5.15`                    |
@@ -161,14 +163,14 @@ For a list of services available, visit the [API library page](https://console.c
 
 ## Configure Terraform
 
-Download Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.1.tar.gz) and extract tarball:
+Download Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.2.tar.gz) and extract tarball:
 ```shell
-curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.1.tar.gz | tar xz
+curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.2.tar.gz | tar xz
 ```
 
 Change Terraform variables according you requirements:
 ```shell
-cd exascaler-cloud-terraform-scripts-2.2.1/gcp
+cd exascaler-cloud-terraform-scripts-2.2.2/gcp
 vi terraform.tfvars
 ```
 
@@ -567,8 +569,8 @@ tar pcfz backup.tgz *.tf terraform.tfvars terraform.tfstate
 Update Terraform scripts using the latest available EXAScaler Cloud Terraform [scripts](https://github.com/DDNStorage/exascaler-cloud-terraform):
 ```shell
 cd /path/to
-curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.1.tar.gz | tar xz
-cd exascaler-cloud-terraform-scripts-2.2.1/gcp
+curl -sL https://github.com/DDNStorage/exascaler-cloud-terraform/archive/refs/tags/scripts/2.2.2.tar.gz | tar xz
+cd exascaler-cloud-terraform-scripts-2.2.2/gcp
 ```
 
 Copy the `terraform.tfstate` file from the existing Terraform directory:


### PR DESCRIPTION
# LOCI-652: EXAScaler Cloud 6.3.2 for Azure and GCP

* Lustre version 2.14.0 ddn182
* RHEL and Rocky Linux 8.10 server images (and CIS-based images for GCP)
* Binary and [DKMS](https://en.wikipedia.org/wiki/Dynamic_Kernel_Module_Support) client packages for RHEL/Alma Linux/Rocky Linux: 7.6-7.9, 8.0-8.10 and 9.0-9.5
* [DKMS](https://en.wikipedia.org/wiki/Dynamic_Kernel_Module_Support) client packages for Ubuntu 18.04, 20.04, 22.04 and 24.04
* Update Terraform Azure provider up to [v4.x.x](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide)